### PR TITLE
Add interfaces for querying

### DIFF
--- a/lib/apiTypes.ts
+++ b/lib/apiTypes.ts
@@ -1,3 +1,9 @@
+export interface QueryResults<Format extends "rows" | "objects"> {
+  queryString: string,
+  metadata: Record<string, any>,
+  data: Format extends "rows" ? any[][] : Record<string, any>[],
+}
+
 interface DatabaseUsage {
   rowsQueried: number;
   periodStart: string;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ import { ApiClient } from "./apiClient";
 import FormData from "form-data";
 import { ReadStream, statSync } from "fs";
 import { Database, ImportJob, QueryResults } from "./apiTypes";
+import { pruneBody, splitDbName, validateDbName, validateToken } from "./utils";
 
 type BaseImportJobOpts = {
   tableName: string;
@@ -45,6 +46,7 @@ class SDK {
     query: string,
     dataFormat: F = "rows" as F,
   ): Promise<QueryResults<F>> {
+    validateDbName(fullDbName);
     let path = "/query";
     if (dataFormat === "objects") {
       path += "?data_format=objects";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import { pruneBody, splitDbName, validateToken } from "./utils";
 import { ApiClient } from "./apiClient";
 import FormData from "form-data";
 import { ReadStream, statSync } from "fs";
-import { Database, ImportJob } from "./apiTypes";
+import { Database, ImportJob, QueryResults } from "./apiTypes";
 
 type BaseImportJobOpts = {
   tableName: string;
@@ -38,6 +38,26 @@ class SDK {
   private _apiClient: ApiClient;
   constructor(apiKey: string) {
     this._apiClient = new ApiClient(apiKey);
+  }
+
+  async query<F extends "rows" | "objects">(
+    fullDbName: string,
+    query: string,
+    dataFormat: F = "rows" as F,
+  ): Promise<QueryResults<F>> {
+    let path = "/query";
+    if (dataFormat === "objects") {
+      path += "?data_format=objects";
+    }
+    return this._apiClient.post<QueryResults<F>>(path, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        database_name: fullDbName,
+        query_string: query,
+      }),
+    });
   }
 
   async listDatabases(): Promise<Database[]> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -279,3 +279,4 @@ function bitdotio(
 }
 
 export default bitdotio;
+module.exports = bitdotio;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,13 +5,17 @@ const packageJson = require("../package.json");
 
 export const VERSION = packageJson.version;
 
+export function validateDbName(dbName: string): void {
+  if (!RE_DB_NAME.test(dbName)) {
+    throw new Error("Invalid database name");
+  }
+}
+
 export function splitDbName(fullName: string): {
   username: string;
   dbName: string;
 } {
-  if (!RE_DB_NAME.test(fullName)) {
-    throw new Error("Invalid database name");
-  }
+  validateDbName(fullName);
   const [username, ...rest] = fullName.split("/");
   return { username, dbName: encodeURIComponent(rest.join("/")) };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.7",
+        "pg": "^8.8.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.3.1",
         "@types/jest": "^29.2.3",
         "@types/node": "^18.11.9",
         "@types/node-fetch": "^2.6.2",
+        "@types/pg": "^8.6.5",
         "@typescript-eslint/parser": "^5.45.0",
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
@@ -1323,6 +1325,17 @@
         "form-data": "^3.0.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -1708,6 +1721,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -4027,6 +4048,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4099,6 +4125,80 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+      "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -4136,6 +4236,41 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prettier": {
@@ -4429,6 +4564,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -4859,6 +5002,14 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -5936,6 +6087,17 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/pg": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz",
+      "integrity": "sha512-tOkGtAqRVkHa/PVZicq67zuujI4Oorfglsr2IbKofDwBSysnaqSx7W1mDqFqdkGE6Fbgh+PZAl0r/BWON/mozw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "@types/prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
@@ -6201,6 +6363,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -7927,6 +8094,11 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7978,6 +8150,61 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pg": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.8.0.tgz",
+      "integrity": "sha512-UXYN0ziKj+AeNNP7VDMwrehpACThH7LUl/p8TDFpEUuSejCUIwGSfxpHsPvtM6/WXFy6SU4E5RG4IJV/TZAGjw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.5.2",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
+      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "requires": {
+        "split2": "^4.1.0"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -8003,6 +8230,29 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
       }
     },
     "prettier": {
@@ -8192,6 +8442,11 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -8494,6 +8749,11 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.9",
     "@types/node-fetch": "^2.6.2",
+    "@types/pg": "^8.6.5",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
@@ -34,6 +35,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "pg": "^8.8.0"
   }
 }

--- a/test/apiMethods.test.ts
+++ b/test/apiMethods.test.ts
@@ -79,6 +79,11 @@ describe("query", () => {
       },
     );
   });
+  test("query invalid db name", async () => {
+    await expect(
+      b.query("not a db name", "SELECT * FROM my_table"),
+    ).rejects.toThrow(new Error("Invalid database name"));
+  });
   test("query error", async () => {
     const dbName = "my/db";
     const query = "SELECT * FROM my_table";

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,0 +1,63 @@
+import { jest } from "@jest/globals";
+import { Client } from "pg";
+import bitdotio from "../lib";
+
+describe("getClient", () => {
+  test("getClient invalid db name", async () => {
+    const b = bitdotio("v2_testtoken");
+    await expect(b.getClient("not a db name")).rejects.toThrow(
+      "Invalid database name",
+    );
+  });
+  test("getClient can't override required opts", async () => {
+    const apiKey = "v2_testtoken";
+    const b = bitdotio(apiKey, {
+      ssl: false,
+      host: "deebee.bit.io",
+      port: 2345,
+      database: "foo/bar",
+      user: "not node_sdk",
+      password: "hunter2",
+    });
+    jest
+      .spyOn(Client.prototype, "connect")
+      .mockImplementationOnce(() => Promise.resolve());
+    const client = await b.getClient("my/db");
+    expect(client.ssl).toBe(true);
+    expect(client.host).toBe("db.bit.io");
+    expect(client.port).toBe(5432);
+    expect(client.database).toBe("my/db");
+    expect(client.user).toBe("node_sdk");
+    expect(client.password).toBe(apiKey);
+  });
+});
+
+describe("getPool", () => {
+  test("getPool invalid db name", () => {
+    const b = bitdotio("v2_testtoken");
+    expect(() => b.getPool("not a db name")).toThrow("Invalid database name");
+  });
+  test("getPool can't override required opts", () => {
+    const apiKey = "v2_testtoken";
+    const b = bitdotio(
+      apiKey,
+      {},
+      {
+        ssl: false,
+        host: "deebee.bit.io",
+        port: 2345,
+        database: "foo/bar",
+        user: "not node_sdk",
+        password: "hunter2",
+      },
+    );
+    const pool = b.getPool("my/db");
+    const options = (pool as any)["options"];
+    expect(options.ssl).toBe(true);
+    expect(options.host).toBe("db.bit.io");
+    expect(options.port).toBe(5432);
+    expect(options.database).toBe("my/db");
+    expect(options.user).toBe("node_sdk");
+    expect(options.password).toBe(apiKey);
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -5,8 +5,30 @@ import {
   pruneBody,
   snakeToCamel,
   splitDbName,
+  validateDbName,
   validateToken
 } from "../lib/utils";
+
+describe("validateDbName", () => {
+  test("valid", () => {
+    expect(() => validateDbName("foo/bar")).not.toThrow();
+    expect(() => validateDbName("foo/bar/baz")).not.toThrow();
+  });
+  test("invalid", () => {
+    const testCases = [
+      "/mydb",
+      "mydb",
+      "myExtremelyLongUserNameWhichIsDefinitelyWayTooLong/db",
+      "me/myExtremelyLongDatabaseNameWhichIsDefinitelyWayTooLong",
+      "-/db",
+      "./db",
+      "me/",
+    ];
+    testCases.forEach((testCase) => {
+      expect(() => validateDbName(testCase)).toThrow("Invalid database name");
+    });
+  });
+});
 
 describe("splitDbName", () => {
   test("splitDbName base case", () => {


### PR DESCRIPTION
**Summary**
- Add the following interfaces to the `SDK` class for running queries:
  - `query`: Queries via API
  - `getClient`: Instantiates and connects a single `pg.Client` for the given database and returns it, basically an unmanaged connection
  - `getPool`: Retrieves/instantiates a `pg.Pool` for the given database
- Add ability to specify options used for instantiating `pg.Client` and `pg.Pool` to the `bitdotio` function
  - SSL, host, port, database, user, and password, are not override-able by the caller

Usage:
```js
// setup
const bitdotio = require('node-bitdotio');
const b = bitdotio(API_KEY);
const myDbPool = b.getPool("my/db");

// run a single query with the pool managing connection acquisition
myDbPool.query("SELECT * FROM my_table").then((results) => console.log(results));

// acquire a connection from the pool and do something
myDbPool.connect().then((client) => {
  client.query("SELECT * FROM my_table").then((results) => {
    console.log(results);
    client.release();
  });
});

// instantiate an unmanaged connection
b.getClient("my/db").then((client) => {
  client.query("SELECT * FROM my_table").then((results) => {
    console.log(results);
    client.end();
  });
});
```

**Test Strategy**
- Added unit tests for all new method
- Tested e2e