### PR TITLE
Add service account management methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ the [bit.io](https://bit.io) developer API.
 npm install @bitdotioinc/node-bitdotio
 ```
 
+
+## Versioning
+
+`node-bitdotio` uses [semantic versioning](https://semver.org/).
+
 ## Usage
 
 The `node-bitdotio` package consists of a `bitdotio` SDK object which provides helpful

--- a/README.md
+++ b/README.md
@@ -366,3 +366,65 @@ _Parameters_:
 _Returns_: `ExportJob` object describing the status and metadata of an export job.
 
 <hr>
+
+#### `bitdotio.listServiceAccounts()`
+
+List metadata pertaining to service accounts the requester has created.
+
+_Returns_: Array of `ServiceAccount` objects describing service account metadata.
+
+<hr>
+
+#### `bitdotio.getServiceAccount(serviceAccountId)`
+
+Get metadata about a single service account
+
+_Parameters_:
+- `serviceAccountId <string>`: ID of the service account
+
+_Returns_: `ServiceAccount` object describing service account metadata.
+
+<hr>
+
+#### `bitdotio.createServiceAccount(serviceAccountId)`
+
+Create a new API key/database password for a given service account
+
+_Parameters_:
+- `serviceAccountId <string>`: ID of the service account
+
+_Returns_: `ApiKey` object containing newly created credentials
+
+<hr>
+
+#### `bitdotio.revokeServiceAccountKeys(serviceAccountId)`
+
+Revoke all API keys/database passwords for the given service account
+
+_Parameters_:
+
+- `serviceAccountId <string>`: ID of the service account
+
+_Returns_: `undefined`
+
+<hr>
+
+#### `bitdotio.createKey()`
+
+Create a new API key/database password with the same permissions as the requester
+
+_Returns_: `ApiKey` object containing newly created credentials
+
+<hr>
+
+#### `bitdotio.revokeKeys([apiKey])`
+
+Revoke API keys/database passwords. If `apiKey` is given, only that API key will
+be revoked. Otherwise, all API keys for the requester will be revoked.
+
+_Kwargs_:
+- `apiKey <string | undefined>`: Optional API key to revoke
+
+_Returns_: `undefined`
+
+<hr>

--- a/lib/apiTypes.ts
+++ b/lib/apiTypes.ts
@@ -33,3 +33,21 @@ export interface ImportJob {
   errorDetails: Record<string, any> | null;
   statusUrl: string;
 }
+
+export interface ServiceAccount {
+  id: string;
+  name: string;
+  dateCreated: string;
+  role: "OWNER" | "ADMIN" | "READER" | "WRITER";
+  databases: {
+    id: string;
+    name: string;
+  }[];
+  tokenCount: number;
+  activeTokenCount: number;
+}
+
+export interface ApiKey {
+  apiKey: string;
+  username: string;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -295,6 +295,15 @@ class SDK {
       `/service-account/${serviceAccountId}/api-key/`,
     );
   }
+
+  async createKey(): Promise<ApiKey> {
+    return this._apiClient.post<ApiKey>("/api-key/");
+  }
+
+  async revokeKeys(apiKey?: string): Promise<void> {
+    const path = apiKey ? `/api-key/?api_key=${apiKey}` : "/api-key/";
+    await this._apiClient.delete(path);
+  }
 }
 
 function bitdotio(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import { ReadStream, statSync } from "fs";
 import FormData from "form-data";
 import { Client, ClientConfig, Pool, PoolConfig } from "pg";
 import { ApiClient } from "./apiClient";
-import { Database, ImportJob, QueryResults } from "./apiTypes";
+import { Database, ImportJob, QueryResults, ServiceAccount } from "./apiTypes";
 import { pruneBody, splitDbName, validateDbName, validateToken } from "./utils";
 
 type BaseImportJobOpts = {
@@ -266,6 +266,18 @@ class SDK {
 
   async getExportJob(jobId: string): Promise<ImportJob> {
     return this._apiClient.get<ImportJob>(`/export/${jobId}`);
+  }
+
+  async listServiceAccounts(): Promise<ServiceAccount[]> {
+    return this._apiClient
+      .get<{ serviceAccounts: ServiceAccount[] }>("/service-account/")
+      .then((response: any) => response.serviceAccounts);
+  }
+
+  async getServiceAccount(serviceAccountId: string): Promise<ServiceAccount> {
+    return this._apiClient.get<ServiceAccount>(
+      `/service-account/${serviceAccountId}`,
+    );
   }
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,7 +2,7 @@ import { ReadStream, statSync } from "fs";
 import FormData from "form-data";
 import { Client, ClientConfig, Pool, PoolConfig } from "pg";
 import { ApiClient } from "./apiClient";
-import { Database, ImportJob, QueryResults, ServiceAccount } from "./apiTypes";
+import { ApiKey, Database, ImportJob, QueryResults, ServiceAccount } from "./apiTypes";
 import { pruneBody, splitDbName, validateDbName, validateToken } from "./utils";
 
 type BaseImportJobOpts = {
@@ -277,6 +277,22 @@ class SDK {
   async getServiceAccount(serviceAccountId: string): Promise<ServiceAccount> {
     return this._apiClient.get<ServiceAccount>(
       `/service-account/${serviceAccountId}`,
+    );
+  }
+
+  async createServiceAccountKey(
+    serviceAccountId: string,
+  ): Promise<ApiKey> {
+    return this._apiClient.post<ApiKey>(
+      `/service-account/${serviceAccountId}/api-key/`,
+    );
+  }
+
+  async revokeServiceAccountKeys(
+    serviceAccountId: string,
+  ): Promise<void> {
+    await this._apiClient.delete(
+      `/service-account/${serviceAccountId}/api-key/`,
     );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitdotioinc/node-bitdotio",
-  "version": "0.0.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitdotioinc/node-bitdotio",
-      "version": "0.0.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitdotioinc/node-bitdotio",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "description": "Node SDK for bit.io",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/apiMethods.test.ts
+++ b/test/apiMethods.test.ts
@@ -427,9 +427,7 @@ describe("revokeServiceAccountKeys", () => {
   const b = bitdotio("v2_testtoken");
 
   test("revokeServiceAccountKeys ok", async () => {
-    jest
-      .spyOn(nf, "default")
-      .mockResolvedValueOnce(mockResponse(200, {}));
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(200, {}));
     const result = await b.revokeServiceAccountKeys("v2_testtoken");
     expect(result).toBeUndefined();
   });
@@ -438,6 +436,74 @@ describe("revokeServiceAccountKeys", () => {
     const data = { error: "whoops" };
     jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
     await expect(b.revokeServiceAccountKeys("v2_testtoken")).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});
+
+describe("createKey", () => {
+  const b = bitdotio("v2_testtoken");
+
+  test("createKey ok", async () => {
+    const expected = { foo: "bar" };
+    jest
+      .spyOn(nf, "default")
+      .mockResolvedValueOnce(mockResponse(200, expected));
+    const result = await b.createKey();
+    expect(result).toEqual(expected);
+  });
+  test("createKey error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.createKey()).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});
+
+describe("revokeKeys", () => {
+  const apiKey = "v2_testtoken";
+  const b = bitdotio(apiKey);
+  const defaultHeaders = {
+    "Accept": "application/json",
+    "Authorization": `Bearer ${apiKey}`,
+    "User-Agent": getUserAgent(),
+  };
+
+  test("revokeKeys ok all", async () => {
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(200, {}));
+    const result = await b.revokeKeys();
+    expect(result).toBeUndefined();
+    expect(nf.default).toHaveBeenLastCalledWith(
+      "https://api.bit.io/v2beta/api-key/",
+      {
+        method: "DELETE",
+        headers: {
+          ...defaultHeaders,
+        },
+      },
+    );
+  });
+  test("revokeKeys ok single", async () => {
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(200, {}));
+    const result = await b.revokeKeys(apiKey);
+    expect(result).toBeUndefined();
+    expect(nf.default).toHaveBeenLastCalledWith(
+      `https://api.bit.io/v2beta/api-key/?api_key=${apiKey}`,
+      {
+        method: "DELETE",
+        headers: {
+          ...defaultHeaders,
+        },
+      },
+    );
+  });
+  test("revokeKeys error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.revokeKeys()).rejects.toThrow(
       new ApiError(apiErrMsg, status, data),
     );
   });

--- a/test/apiMethods.test.ts
+++ b/test/apiMethods.test.ts
@@ -401,3 +401,44 @@ describe("getServiceAccount", () => {
     );
   });
 });
+
+describe("createServiceAccountKey", () => {
+  const b = bitdotio("v2_testtoken");
+
+  test("createServiceAccountKey ok", async () => {
+    const expected = { foo: "bar" };
+    jest
+      .spyOn(nf, "default")
+      .mockResolvedValueOnce(mockResponse(200, expected));
+    const result = await b.createServiceAccountKey("v2_testtoken");
+    expect(result).toEqual(expected);
+  });
+  test("createServiceAccountKey error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.createServiceAccountKey("v2_testtoken")).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});
+
+describe("revokeServiceAccountKeys", () => {
+  const b = bitdotio("v2_testtoken");
+
+  test("revokeServiceAccountKeys ok", async () => {
+    jest
+      .spyOn(nf, "default")
+      .mockResolvedValueOnce(mockResponse(200, {}));
+    const result = await b.revokeServiceAccountKeys("v2_testtoken");
+    expect(result).toBeUndefined();
+  });
+  test("revokeServiceAccountKeys error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.revokeServiceAccountKeys("v2_testtoken")).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});

--- a/test/apiMethods.test.ts
+++ b/test/apiMethods.test.ts
@@ -359,3 +359,45 @@ describe("getExportJob", () => {
     ).rejects.toThrow(new ApiError(apiErrMsg, status, data));
   });
 });
+
+describe("listServiceAccounts", () => {
+  const b = bitdotio("v2_testtoken");
+
+  test("listServiceAccounts ok", async () => {
+    const expected = [{ foo: "bar" }];
+    jest
+      .spyOn(nf, "default")
+      .mockResolvedValueOnce(mockResponse(200, { service_accounts: expected }));
+    const result = await b.listServiceAccounts();
+    expect(result).toEqual(expected);
+  });
+  test("listServiceAccounts error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.listServiceAccounts()).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});
+
+describe("getServiceAccount", () => {
+  const b = bitdotio("v2_testtoken");
+
+  test("getServiceAccount ok", async () => {
+    const expected = { foo: "bar" };
+    jest
+      .spyOn(nf, "default")
+      .mockResolvedValueOnce(mockResponse(200, expected));
+    const result = await b.getServiceAccount("my-service-account");
+    expect(result).toEqual(expected);
+  });
+  test("getServiceAccount error", async () => {
+    const status = 400;
+    const data = { error: "whoops" };
+    jest.spyOn(nf, "default").mockResolvedValueOnce(mockResponse(status, data));
+    await expect(b.getServiceAccount("my-service-account")).rejects.toThrow(
+      new ApiError(apiErrMsg, status, data),
+    );
+  });
+});


### PR DESCRIPTION
Add methods for managing service accounts corresponding to developer API functionality:
- `listServiceAccounts`
- `getServiceAccount`
- `createServiceAccountKey`
- `revokeServiceAccountKeys`
- `createKey`
- `revokeKeys`

All methods unit tested as well as tested e2e, and docs added